### PR TITLE
Add more detailed setup guide and manifest to easily create a read-only Slack app

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,30 @@ This project is a fork of [marek/fslack](https://github.com/marek/fslack), used 
 * `python-requests`: web request library for Python
 
 
-### Accessing Your Slack Workspace
+### Setting up API Access to your Slack Workspace
+
 In order to get your token, you will have to create a new Slack App. You can follow [this tutorial](https://api.slack.com/tutorials/tracks/getting-a-token).
-Once you have the app, you have to install it in your workspace. Once it is installed, invite the App's bot into the channels from which you want to download the files.
-To invite the bot, use `\invite @your-app-name` as discussed in [this question](https://stackoverflow.com/a/61369364/8691571)
+
+You can create a new app by going to https://api.slack.com/apps and clicking on the `"Create New App"` button.
+
+When you click on the `"Create New App"` button, you will be given the following 2 options:
+
+1. Create an app from scratch
+2. Create an app from an app manifest
+
+Select "Create an app from an app manifest" and then copy and paste the text in [slack-app-manifest.yaml](slack-app-manifest.yaml)
+
+This will create an app with permission to read all data in your Slack workspace. It won't have any write permissions.
+
+Once you have created the app, you have to install it in your workspace. 
+
+Now - to get the token, go to the `OAuth & Permissions` section in the app settings. Then in the `OAuth Tokens for Your Workspace` section, copy the `Bot User OAuth Token`.
+
+To access app `OAuth & Permissions` settings, you can navigate directly to `https://api.slack.com/apps/<app_id>/oauth?`
+
+Finally, invite the App's bot into the channels from which you want to download the files.
+
+To invite the bot, use `/invite @your-app-name` e.g. `/invite @Slack Data Downloader` as discussed in [this question](https://stackoverflow.com/a/61369364/8691571)
 
 
 ### Installation Instructions

--- a/slack-app-manifest.yaml
+++ b/slack-app-manifest.yaml
@@ -1,0 +1,41 @@
+display_information:
+  name: Slack Data Downloader
+features:
+  bot_user:
+    display_name: Slack Data Downloader
+    always_online: false
+oauth_config:
+  scopes:
+    bot:
+      - app_mentions:read
+      - bookmarks:read
+      - calls:read
+      - channels:history
+      - channels:read
+      - conversations.connect:read
+      - files:read
+      - groups:history
+      - groups:read
+      - im:history
+      - im:read
+      - links:read
+      - metadata.message:read
+      - mpim:history
+      - mpim:read
+      - pins:read
+      - reactions:read
+      - remote_files:read
+      - team:read
+      - users:read.email
+      - users:read
+      - users.profile:read
+      - dnd:read
+      - emoji:read
+      - reminders:read
+      - team.billing:read
+      - team.preferences:read
+      - usergroups:read
+settings:
+  org_deploy_enabled: false
+  socket_mode_enabled: false
+  token_rotation_enabled: false


### PR DESCRIPTION
More detailed instructions and the app manifest will make it easier for people to configure a Slack app with the correct permissions, and start using this software.